### PR TITLE
Add igraph/ prefix in include path

### DIFF
--- a/cmake/FindIGRAPH.cmake
+++ b/cmake/FindIGRAPH.cmake
@@ -17,11 +17,11 @@ else()
     set(IGRAPH_NAME libigraph.a igraph)
 endif()
 
-find_path (IGRAPH_INCLUDES igraph.h
+find_path (IGRAPH_INCLUDES igraph/igraph.h
         PATHS ${CMAKE_EXTRA_INCLUDES} PATH_SUFFIXES igraph/ igraph/include NO_DEFAULT_PATH
         )
 if(NOT IGRAPH_INCLUDES)
-    find_path (IGRAPH_INCLUDES igraph.h
+    find_path (IGRAPH_INCLUDES igraph/igraph.h
             PATHS /usr/local/include /usr/include /include /sw/include /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu/ ${CMAKE_EXTRA_INCLUDES} PATH_SUFFIXES igraph/ igraph/include
             )
 endif(NOT IGRAPH_INCLUDES)


### PR DESCRIPTION
Fixes
```
/Users/lenny/repos/leidenalg/include/GraphHelper.h:4:10: fatal error: 'igraph/igraph.h' file not found
#include <igraph/igraph.h>
```

It seems that leidenalg's cmake build expects the full `igraph/igraph.h` (with the `igraph/` directory prefix).  This fixes the build issue on MacOS, not sure if it affects Linux